### PR TITLE
feat: add OS dark mode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+**/__pycache__/
+**/*.py[cod]
+
+venv/
+env/
+.venv/
+.env/
+
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+config/*.json
+.python-version
+.env

--- a/ui.py
+++ b/ui.py
@@ -2,7 +2,7 @@ import os, json, time, math, random, threading
 import tkinter as tk
 from collections import deque
 from PIL import Image, ImageTk, ImageDraw
-import sys
+import sys, ctypes
 from pathlib import Path
 
 
@@ -48,6 +48,8 @@ class JarvisUI:
 
         self.W = W
         self.H = H
+
+        self._apply_dark_theme()
 
         self.FACE_SZ = min(int(H * 0.54), 400)
         self.FCX     = W // 2
@@ -124,6 +126,31 @@ class JarvisUI:
 
         self._animate()
         self.root.protocol("WM_DELETE_WINDOW", lambda: os._exit(0))
+
+
+    def _apply_dark_theme(self):
+        if not hasattr(ctypes, "windll"):
+            return
+
+        self.root.withdraw()
+        self.root.update_idletasks()
+
+        HWND = ctypes.windll.user32.GetParent(self.root.winfo_id())
+        VALUE = ctypes.c_int(1)
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+
+        S_OK = 0x0
+        E_INVALIDARG = 0x80070057
+      
+        _apply_dark_theme = lambda: ctypes.windll.dwmapi.DwmSetWindowAttribute(HWND, DWMWA_USE_IMMERSIVE_DARK_MODE, ctypes.byref(VALUE), ctypes.sizeof(ctypes.c_int))
+        _apply_dark_theme_result = _apply_dark_theme()
+
+        if _apply_dark_theme_result == E_INVALIDARG:
+            DWMWA_USE_IMMERSIVE_DARK_MODE = 19
+            _apply_dark_theme_result = _apply_dark_theme()
+
+        self.root.deiconify()
+    
 
     # ── Mute butonu ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Overview

This PR introduces immersive dark mode support on recent Windows operating systems. The implemented code checks if the OS is Windows and attempts to change the mode of the window from light to dark mode. 


## Key Changes

### Dark Mode Switch 

* Implemented the `_apply_dark_theme` instance method in `JarvisUI` in `ui.py` to set the main window's mode to dark mode using the `DWMWA_USE_IMMERSIVE_DARK_MODE` attribute.
* Included error handling for `E_INVALIDARG` to support both older and newer builds of Windows 10 and 11 (switching between attributes 19 and 20).
* Added a withdraw/deiconify sequence during theme application to prevent visual glitches and ensure a clean render. 
* Added a check that checks the operating system of the user to determine whether to attempt mode changing.

### .gitignore Addition
* Added `.gitignore` file to prevent exfiltration of secrets and uploading unnecessary files to the branch.