### PR TITLE
Add Jarvis → Claude → Copilot voice dev loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Secrets — never commit real API keys
+config/api_keys.json
+
+# Runtime state (per-machine, not code)
+memory/claude_sessions.json
+memory/current_project.json
+memory/long_term.json
+
+# Virtual environment
+.venv/
+venv/
+env/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+
+# OS / editor
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/

--- a/actions/ask_claude.py
+++ b/actions/ask_claude.py
@@ -1,0 +1,127 @@
+# actions/ask_claude.py
+# The relay: routes a voice request to Claude (the architect) via the `claude` CLI,
+# headless, scoped to the active project, with conversation memory across turns.
+#
+# Claude's job (defined by its own CLAUDE.md / system prompt later, Phase 3):
+#   take the user's top-level decision -> brief Copilot to write code -> review -> report.
+# This module is only the transport.
+
+import json
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+from actions.project_resolver import resolve
+
+_SESSIONS_FILE = Path(__file__).resolve().parent.parent / "memory" / "claude_sessions.json"
+_DEFAULT_TIMEOUT = 300  # seconds; raise once Copilot builds are wired in (Phase 3)
+
+
+def _claude_bin() -> str:
+    return shutil.which("claude") or r"C:\Users\Csaba\.local\bin\claude.exe"
+
+
+def _load_sessions() -> dict:
+    try:
+        return json.loads(_SESSIONS_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_session(key: str, session_id: str) -> None:
+    sessions = _load_sessions()
+    sessions[key] = session_id
+    try:
+        _SESSIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _SESSIONS_FILE.write_text(json.dumps(sessions, indent=2), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _parse_result(stdout: str) -> tuple[str, str | None]:
+    """Returns (text, session_id) from claude --output-format json."""
+    try:
+        data = json.loads(stdout)
+        text = (data.get("result") or "").strip()
+        sid = data.get("session_id")
+        return text or stdout.strip(), sid
+    except Exception:
+        return stdout.strip(), None
+
+
+def ask_claude(
+    parameters: dict,
+    response=None,
+    player=None,
+    session_memory=None,
+    speak=None,
+) -> str:
+    """
+    parameters:
+      request     : (required) what to ask Claude
+      project     : optional project-name override; else auto-follow active VS Code
+      new_session : optional bool; start a fresh conversation instead of resuming
+    """
+    p = parameters or {}
+    request = (p.get("request") or "").strip()
+    if not request:
+        return "What would you like me to ask Claude, sir?"
+
+    project_dir, source = resolve(p.get("project"))
+    if project_dir is None:
+        return ("I couldn't tell which project to use, sir. "
+                "Open it in VS Code or name it explicitly.")
+
+    if player:
+        player.write_log(f"[ask_claude] {project_dir.name}: {request[:40]}")
+    print(f"[ask_claude] project={project_dir} (via {source}) :: {request[:60]}")
+
+    key = str(project_dir).lower()
+    sid = _load_sessions().get(key)
+    new_session = bool(p.get("new_session", False))
+
+    cmd = [
+        _claude_bin(), "-p", request,
+        "--output-format", "json",
+        "--permission-mode", "bypassPermissions",
+        "--add-dir", str(project_dir),
+    ]
+    if sid and not new_session:
+        cmd += ["--resume", sid]
+    else:
+        sid = str(uuid.uuid4())
+        cmd += ["--session-id", sid]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(project_dir),
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            timeout=_DEFAULT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Claude took too long on {project_dir.name} and timed out, sir."
+    except Exception as e:
+        return f"Could not reach Claude: {e}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        # a stale/parallel session can break --resume; retry once fresh
+        if "--resume" in cmd and ("session" in err.lower() or not err):
+            return ask_claude(
+                {**p, "new_session": True},
+                response, player, session_memory, speak,
+            )
+        return f"Claude errored on {project_dir.name}: {err[:200]}"
+
+    text, returned_sid = _parse_result(proc.stdout)
+    _save_session(key, returned_sid or sid)
+    return text or "Claude returned nothing, sir."
+
+
+if __name__ == "__main__":
+    import sys
+    req = " ".join(sys.argv[1:]) or "Reply with exactly: PONG"
+    print(ask_claude({"request": req}))

--- a/actions/ask_claude.py
+++ b/actions/ask_claude.py
@@ -15,7 +15,32 @@ from pathlib import Path
 from actions.project_resolver import resolve
 
 _SESSIONS_FILE = Path(__file__).resolve().parent.parent / "memory" / "claude_sessions.json"
-_DEFAULT_TIMEOUT = 300  # seconds; raise once Copilot builds are wired in (Phase 3)
+_DEFAULT_TIMEOUT = 600  # seconds; builds (Copilot + tests) can take a few minutes
+
+
+def _orchestration_prompt(project_dir: Path) -> str:
+    return (
+        "You are the architect half of a voice-driven dev loop. The user speaks to a "
+        "voice assistant (Jarvis), which relays their request to you here in the terminal. "
+        f"You are working ONLY inside: {project_dir}\n\n"
+        "Roles & rules:\n"
+        "- The user makes the top-level / architecture decisions; you turn them into action.\n"
+        "- QUESTION or BRIEFING (e.g. 'what's the next phase', 'explain X'): just answer. "
+        "Do NOT change code.\n"
+        "- BUILD request (e.g. 'build X', 'implement Y'): do NOT write the bulk code yourself. "
+        "Instead:\n"
+        "  1. Decide the framework-level approach (architecture + tests); leave small "
+        "implementation choices to Copilot.\n"
+        "  2. Hand the actual coding to Copilot with a precise prompt:\n"
+        f'     copilot -p "<your detailed prompt>" --allow-all-tools --add-dir "{project_dir}"\n'
+        "  3. After Copilot writes the code, YOU run the tests and review the diff (git diff).\n"
+        "  4. Commit on a NEW branch. NEVER commit to main. NEVER push. NEVER merge.\n"
+        "  5. Report: what was built, test results, your verdict.\n"
+        "- Boundary: never touch anything outside the project directory above.\n"
+        "- The user pushes and merges themselves — you never do.\n\n"
+        "Every reply is read aloud by a voice assistant: keep it SHORT, plain English, "
+        "a few sentences, no code dumps."
+    )
 
 
 def _claude_bin() -> str:
@@ -86,6 +111,7 @@ def ask_claude(
         "--output-format", "json",
         "--permission-mode", "bypassPermissions",
         "--add-dir", str(project_dir),
+        "--append-system-prompt", _orchestration_prompt(project_dir),
     ]
     if sid and not new_session:
         cmd += ["--resume", sid]

--- a/actions/project_resolver.py
+++ b/actions/project_resolver.py
@@ -1,0 +1,173 @@
+# actions/project_resolver.py
+# Resolves which project folder Jarvis should aim Claude+Copilot at.
+#
+# Resolution order:
+#   1. Explicit name from the voice request  ("...the lead-flow project")
+#   2. Auto-follow: the folder open in the active VS Code window
+#   3. Sticky fallback: the last project we resolved (memory/current_project.json)
+#
+# Hard boundary: the resolved path MUST live directly under PROJECTS_ROOT.
+
+import json
+import subprocess
+from pathlib import Path
+
+PROJECTS_ROOT = Path(r"C:\Users\Csaba\Projects")
+_STATE_FILE   = Path(__file__).resolve().parent.parent / "memory" / "current_project.json"
+_VSCODE_SUFFIX = "Visual Studio Code"
+
+
+# ── project listing / matching ────────────────────────────────────────────────
+
+def list_projects() -> list[str]:
+    """Folder names directly under the Projects root."""
+    if not PROJECTS_ROOT.exists():
+        return []
+    return sorted(p.name for p in PROJECTS_ROOT.iterdir() if p.is_dir())
+
+
+def _norm(s: str) -> str:
+    return s.lower().replace("-", "").replace("_", "").replace(" ", "")
+
+
+def _match_name(name: str) -> Path | None:
+    """Map a spoken/typed project name to a real folder (fuzzy, separator-insensitive)."""
+    if not name:
+        return None
+    target = _norm(name)
+    projects = list_projects()
+    # exact-ish first
+    for p in projects:
+        if _norm(p) == target:
+            return PROJECTS_ROOT / p
+    # then contains
+    for p in projects:
+        if target in _norm(p) or _norm(p) in target:
+            return PROJECTS_ROOT / p
+    return None
+
+
+# ── auto-follow the active VS Code window ─────────────────────────────────────
+
+def _vscode_titles() -> list[str]:
+    try:
+        import pygetwindow as gw
+    except Exception:
+        return []
+    titles = []
+    try:
+        active = gw.getActiveWindow()
+        if active and active.title and active.title.strip().endswith(_VSCODE_SUFFIX):
+            titles.append(active.title)            # prefer the focused window
+    except Exception:
+        pass
+    try:
+        for t in gw.getAllTitles():
+            if t and t.strip().endswith(_VSCODE_SUFFIX) and t not in titles:
+                titles.append(t)
+    except Exception:
+        pass
+    return titles
+
+
+def _folder_from_title(title: str) -> str | None:
+    """'file - folder - Visual Studio Code' -> 'folder'."""
+    parts = [p.strip() for p in title.split(" - ")]
+    if len(parts) < 2 or not parts[-1].endswith(_VSCODE_SUFFIX):
+        return None
+    folder = parts[-2]
+    # strip dirty marker / admin prefix
+    folder = folder.lstrip("●").strip()
+    if folder.startswith("[Administrator]"):
+        folder = folder.split("]", 1)[-1].strip()
+    return folder or None
+
+
+def active_vscode_folder() -> Path | None:
+    for title in _vscode_titles():
+        folder = _folder_from_title(title)
+        if not folder:
+            continue
+        match = _match_name(folder)
+        if match:
+            return match
+    return None
+
+
+# ── sticky state ──────────────────────────────────────────────────────────────
+
+def _load_sticky() -> Path | None:
+    try:
+        data = json.loads(_STATE_FILE.read_text(encoding="utf-8"))
+        p = Path(data.get("current_project", ""))
+        if p.exists():
+            return p
+    except Exception:
+        pass
+    return None
+
+
+def _save_sticky(path: Path) -> None:
+    try:
+        _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _STATE_FILE.write_text(
+            json.dumps({"current_project": str(path)}, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+def _within_boundary(path: Path) -> bool:
+    try:
+        return path.resolve().parent == PROJECTS_ROOT.resolve() and path.exists()
+    except Exception:
+        return False
+
+
+def resolve(name: str | None = None) -> tuple[Path | None, str]:
+    """
+    Returns (project_path, source). source is one of:
+      'name' | 'vscode' | 'sticky' | 'none'
+    Only returns a path that sits directly under PROJECTS_ROOT.
+    """
+    if name:
+        m = _match_name(name)
+        if m and _within_boundary(m):
+            _save_sticky(m)
+            return m, "name"
+
+    auto = active_vscode_folder()
+    if auto and _within_boundary(auto):
+        _save_sticky(auto)
+        return auto, "vscode"
+
+    sticky = _load_sticky()
+    if sticky and _within_boundary(sticky):
+        return sticky, "sticky"
+
+    return None, "none"
+
+
+def open_in_vscode(path: Path, replace: bool = False) -> str:
+    """Open a folder in VS Code. replace=True swaps the current window."""
+    if not _within_boundary(path):
+        return f"Refused: '{path}' is outside the projects boundary."
+    args = ["code"] + (["-r"] if replace else []) + [str(path)]
+    try:
+        subprocess.Popen(args, shell=True)
+        return f"Opened {path.name} in VS Code."
+    except Exception as e:
+        return f"Could not open VS Code: {e}"
+
+
+if __name__ == "__main__":
+    # quick self-test
+    print("Projects root:", PROJECTS_ROOT)
+    print("Projects:", list_projects())
+    print("VS Code titles:", _vscode_titles())
+    print("Active VS Code folder:", active_vscode_folder())
+    path, source = resolve()
+    print(f"resolve() -> {path}  (via {source})")

--- a/config/api_keys.example.json
+++ b/config/api_keys.example.json
@@ -1,0 +1,5 @@
+{
+    "gemini_api_key": "YOUR_GEMINI_API_KEY_HERE",
+    "openrouter_api_key": "YOUR_OPENROUTER_API_KEY_HERE",
+    "os_system": "windows"
+}

--- a/main.py
+++ b/main.py
@@ -5,6 +5,13 @@ import sys
 import traceback
 from pathlib import Path
 
+# Ensure console can print emoji/Unicode on Windows (cp1252 consoles otherwise crash).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 import sounddevice as sd
 from google import genai
 from google.genai import types
@@ -28,6 +35,7 @@ from actions.browser_control   import browser_control
 from actions.file_controller   import file_controller
 from actions.code_helper       import code_helper
 from actions.dev_agent         import dev_agent
+from actions.ask_claude        import ask_claude
 from actions.web_search        import web_search as web_search_action
 from actions.computer_control  import computer_control
 from actions.game_updater      import game_updater
@@ -297,6 +305,26 @@ TOOL_DECLARATIONS = [
                 "timeout":      {"type": "INTEGER", "description": "Run timeout in seconds (default: 30)"},
             },
             "required": ["description"]
+        }
+    },
+    {
+        "name": "ask_claude",
+        "description": (
+            "Ask Claude — the architect running in the terminal — about the current project. "
+            "Use for briefings, design decisions, planning the next phase, reviewing, or building "
+            "features (Claude briefs Copilot to write the code). Works on whichever project is open "
+            "in VS Code unless a project is named. Examples: 'ask Claude what the next phase is', "
+            "'have Claude design the login flow', 'ask Claude to build phase 4'. "
+            "Conversation is remembered across turns."
+        ),
+        "parameters": {
+            "type": "OBJECT",
+            "properties": {
+                "request":     {"type": "STRING", "description": "What to ask Claude — the user's question or instruction"},
+                "project":     {"type": "STRING", "description": "Optional project-name override; omit to auto-follow the open VS Code folder"},
+                "new_session": {"type": "BOOLEAN", "description": "True to start a fresh conversation instead of continuing the last one"},
+            },
+            "required": ["request"]
         }
     },
     {
@@ -660,6 +688,10 @@ class JarvisLive:
             elif name == "dev_agent":
                 r = await loop.run_in_executor(None, lambda: dev_agent(parameters=args, player=self.ui, speak=self.speak))
                 result = r or "Done."
+
+            elif name == "ask_claude":
+                r = await loop.run_in_executor(None, lambda: ask_claude(parameters=args, player=self.ui, speak=self.speak))
+                result = r or "Claude returned nothing, sir."
 
             elif name == "agent_task":
                 from agent.task_queue import get_queue, TaskPriority

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -137,30 +137,35 @@ def update_memory(memory_update: dict) -> dict:
     return memory
 
 
+# Local signals that a turn might hold a personal fact worth saving.
+# Cheap heuristic gate so we DON'T spend an LLM call on every single utterance —
+# the costly extract_memory() pass only runs when one of these appears.
+_MEMORY_SIGNALS = (
+    "my name", "call me", "i am ", "i'm ", "i was born", "my birthday",
+    "i live", "i'm from", "i am from", "my number", "my email",
+    "i like", "i love", "i prefer", "i hate", "i don't like",
+    "favorite", "favourite",
+    "i work", "my job", "i study", "my school", "my project",
+    "i'm working on", "i am working on", "i have a", "i've got",
+    "i want to", "i'd like to", "i plan to", "remind me", "remember that",
+    "my brother", "my sister", "my mom", "my mother", "my dad", "my father",
+    "my wife", "my husband", "my girlfriend", "my boyfriend", "my friend",
+    "my partner", "my son", "my daughter", "my dog", "my cat",
+)
+
+
 def should_extract_memory(user_text: str, jarvis_text: str, api_key: str = "") -> bool:
-    try:
-        from or_client import client
+    """Local heuristic gate — no network call.
 
-        combined = f"User: {user_text[:300]}\nJarvis: {jarvis_text[:1000]}"
-
-        result = client.chat(
-            f"Does this conversation contain ANY of the following?\n"
-            f"- Personal facts (name, age, city, job, birthday, nationality)\n"
-            f"- Preferences or favorites (food, color, music, sport, game, film, book, etc.)\n"
-            f"- Active projects or goals the user is working on\n"
-            f"- People in the user's life (friends, family, partner, colleagues)\n"
-            f"- Things the user wants to do or buy in the future\n"
-            f"- Any other fact worth remembering long-term\n\n"
-            f"Reply only YES or NO.\n\nConversation:\n{combined}",
-            system="You are a memory relevance checker. Reply only YES or NO.",
-            max_tokens=5,
-            temperature=0.0,
-        )
-        return "YES" in result.upper()
-
-    except Exception as e:
-        print(f"[Memory] ⚠️ Stage1 check failed: {e}")
+    Returns True only when the user's text shows a plausible personal-fact
+    signal, so the (LLM-backed) extract_memory() runs rarely instead of on
+    every transcribed fragment. English-centric; extend _MEMORY_SIGNALS for
+    other languages as needed.
+    """
+    text = (user_text or "").lower()
+    if len(text) < 8:
         return False
+    return any(sig in text for sig in _MEMORY_SIGNALS)
 
 
 def extract_memory(user_text: str, jarvis_text: str, api_key: str = "") -> dict:


### PR DESCRIPTION
Wires a voice-driven dev workflow into the MARK/Jarvis assistant: speak to Jarvis → it relays to Claude (terminal) → Claude briefs Copilot to write code → tests → commits on a branch → Jarvis reads back the verdict.

Changes:
- actions/project_resolver.py: resolve the target project — auto-follows the
  active VS Code window, accepts a spoken name override, sticky fallback;
  confined to the Projects boundary.
- actions/ask_claude.py: headless `claude -p` relay with per-project session
  continuity and an orchestration system prompt (answer questions; brief Copilot
  for builds, test, commit on a branch — never push or merge).
- main.py: register the ask_claude tool; force UTF-8 stdout/stderr so emoji
  logs don't crash on cp1252 consoles.
- memory/memory_manager.py: replace the per-turn LLM memory check with a local
  keyword heuristic — eliminates constant OpenRouter calls (CPU/lag fix).
- .gitignore + config/api_keys.example.json: ignore secrets/runtime state,
  add a key template.

Tested live: voice request built a working, tested guitar tuner on its own branch.
